### PR TITLE
Fix walking the cause-stack for '%r'

### DIFF
--- a/lib/extsprintf.js
+++ b/lib/extsprintf.js
@@ -155,8 +155,12 @@ function dumpException(ex)
 	/* Note that V8 prepends "ex.stack" with ex.toString(). */
 	ret = 'EXCEPTION: ' + ex.constructor.name + ': ' + ex.stack;
 
-	if (ex.cause && typeof (ex.cause) === 'function')
-		ret += '\nCaused by: ' + dumpException(ex.cause());
+	if (ex.cause && typeof (ex.cause) === 'function') {
+		var cex = ex.cause();
+		if (cex) {
+			ret += '\nCaused by: ' + dumpException(cex);
+		}
+	}
 
 	return (ret);
 }


### PR DESCRIPTION
A VError chain more than 2 levels deep:

```
$ cat deep.js 
var sprintf = require('./lib/extsprintf').sprintf;
var VError = require('verror').VError;

var eBottom = new TypeError("bottom");
var eMid = new VError(eBottom, "middle");
var eTop = new VError(eMid, "top");
console.log(sprintf("the stack is: %r", eTop));
```

The problem (incorrect recursion on causes):

```
$ node deep.js 
the stack is: EXCEPTION: VError: top: middle: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:6:12)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
Caused by: EXCEPTION: VError: middle: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:5:12)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
Caused by: EXCEPTION: TypeError: TypeError: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:4:15)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
Caused by: EXCEPTION: TypeError: TypeError: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:4:15)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

With the fix:

```
$ node deep.js 
the stack is: EXCEPTION: VError: top: middle: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:6:12)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
Caused by: EXCEPTION: VError: middle: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:5:12)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
Caused by: EXCEPTION: TypeError: TypeError: bottom
    at Object.<anonymous> (/Users/trentm/tm/node-extsprintf/deep.js:4:15)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```
