### PR TITLE
node-extsprintf#4 should support %x (hexadecimal) conversion

### DIFF
--- a/lib/extsprintf.js
+++ b/lib/extsprintf.js
@@ -107,6 +107,10 @@ function jsSprintf(fmt)
 			    arg.toString());
 			break;
 
+		case 'x':
+			ret += doPad(pad, width, left, arg.toString(16));
+			break;
+
 		case 'j': /* non-standard */
 			if (width === 0)
 				width = 10;


### PR DESCRIPTION
Fixes davepacheco/node-extsprintf#4.
