### PR TITLE
add .npmignore file to reduce install size significantly

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/deps
+/examples


### PR DESCRIPTION
npm package size before:

```
[23:27:42 trentm@grape:~/tm/node-extsprintf ((2e28082...))]
$ npm pack
extsprintf-1.1.0.tgz
[23:27:47 trentm@grape:~/tm/node-extsprintf ((2e28082...))]
$ ls -al extsprintf-1.1.0.tgz
-rw-r--r--  1 trentm  staff   851K Jun 12 23:27 extsprintf-1.1.0.tgz
```

and after:

```
[23:28:58 trentm@grape:~/tm/node-extsprintf (npmignore)]
$ npm pack
extsprintf-1.1.0.tgz
[23:29:01 trentm@grape:~/tm/node-extsprintf (npmignore)]
$ ls -al extsprintf-1.1.0.tgz
-rw-r--r--  1 trentm  staff   8.9K Jun 12 23:29 extsprintf-1.1.0.tgz
```

Mainly this drops the 4MB from deps/javascriptlint. If you get a chance, a new published rev with this would be helpful.
